### PR TITLE
Added CORS

### DIFF
--- a/PAC/settings.py
+++ b/PAC/settings.py
@@ -39,10 +39,11 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'articles',
     'rest_framework',
-    'rest_framework.authtoken'
+    'rest_framework.authtoken',
+    'corsheaders'
 ]
 
-REST_FRAMEWORK = { 
+REST_FRAMEWORK = {
         'DEFAULT_AUTHENTICATION_CLASSES':(
             'rest_framework.authentication.SessionAuthentication',
             'rest_framework.authentication.TokenAuthentication',
@@ -60,6 +61,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'corsheaders.middleware.CorsMiddleware'
 ]
 
 ROOT_URLCONF = 'PAC.urls'
@@ -132,3 +134,6 @@ USE_TZ = True
 STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 STATIC_URL = '/static/'
 #STATICFILES_DIRS = (os.path.join(BASE_DIR,'static'),)
+
+# Allow CORS Request
+CORS_ORIGIN_ALLOW_ALL = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ requests==2.13.0
 requests-file==1.4.1
 six==1.10.0
 tldextract==2.0.2
+django-cors-headers==2.0.2


### PR DESCRIPTION
By default, browsers don't allow Cross-Origin Resource Sharing. 
By supporting CORS requests, our api can add a few special response headers that allows other websites to access the data. Necessary while creating API's to be used by various platforms.

Read more here: https://www.html5rocks.com/en/tutorials/cors/